### PR TITLE
Josiah - Article Table Delete Column

### DIFF
--- a/frontend/src/main/components/Articles/ArticlesTable.js
+++ b/frontend/src/main/components/Articles/ArticlesTable.js
@@ -1,6 +1,30 @@
-import OurTable from "main/components/OurTable";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { hasRole } from "main/utils/currentUser";
 
-export default function ArticlesTable({ articles, _currentUser }) {
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/article",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+
+export default function ArticlesTable({ articles, currentUser }) {
+
+    // Stryker disable all : hard to test for query caching
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/article/all"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
     const columns = [
         {
@@ -31,9 +55,16 @@ export default function ArticlesTable({ articles, _currentUser }) {
 
     const testid = "ArticlesTable";
 
+    const columnsIfAdmin = [
+        ...columns,
+        ButtonColumn("Delete", "danger", deleteCallback, testid)
+    ];
+
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
     return <OurTable
         data={articles}
-        columns={columns}
+        columns={columnsToDisplay}
         testid={testid}
     />;
 };

--- a/frontend/src/main/components/Articles/ArticlesTable.js
+++ b/frontend/src/main/components/Articles/ArticlesTable.js
@@ -53,11 +53,11 @@ export default function ArticlesTable({ articles, currentUser }) {
         }
     ];
 
-    const testid = "ArticlesTable";
+    const testId = "ArticlesTable";
 
     const columnsIfAdmin = [
         ...columns,
-        ButtonColumn("Delete", "danger", deleteCallback, testid)
+        ButtonColumn("Delete", "danger", deleteCallback, testId)
     ];
 
     const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
@@ -65,6 +65,6 @@ export default function ArticlesTable({ articles, currentUser }) {
     return <OurTable
         data={articles}
         columns={columnsToDisplay}
-        testid={testid}
+        testid={testId}
     />;
 };

--- a/frontend/src/tests/components/Articles/ArticlesTable.test.js
+++ b/frontend/src/tests/components/Articles/ArticlesTable.test.js
@@ -86,5 +86,9 @@ describe("ArticlesTable tests", () => {
     expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(2);
     expect(getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent("Midterm Elections");
     expect(getByTestId(`${testId}-cell-row-1-col-title`)).toHaveTextContent("Best meals from Portola");
+
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
   });
 });


### PR DESCRIPTION
Closes #38 

- [x] Now, In the storybook there is an `Articles` Folder with a `ArticlesTable` Inside with `Empty`, `Three Articles`, and `Three Articles as Admin`.
- [x] When `Three Articles as Admin` is clicked there is a table with all of the headers of an article plus a delete header with three items in the table with the correct values corresponding to the values in the `articlesFixtures.js` file each row also contains a delete button under the delete header.
- [x] When the user presses one of the delete buttons on the articles list page, the corresponding article is deleted from the database and the page updates to show so.
- [x] Everything has full test coverage
- [x] Everything has full mutation coverage
- [x] Everything works when tested locally
- [x] Storybook shows up without errors at https://ucsb-cs156-f22.github.io/team03-f22-5pm-3-docs-qa/
- [x] Everything works when tested on heroku