### PR TITLE
27 AK add placeholder for organization index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # STARTER-team03
 
-TODO: Add a codecov badge for the main branch here.  What's shown is an example, but you need to visit codecov to get the markdown for your repo; don't just try to edit the markdown in the example below.  The token value won't match your repo.  Be sure to adjust the default branch from `master` to `main`.
-
-[![codecov](https://codecov.io/gh/ucsb-cs156-f22/STARTER-team03/branch/main/graph/badge.svg?token=s3OvSANaki)](https://codecov.io/gh/ucsb-cs156-f22/STARTER-team03)
 
 * Production Deployment: <https://f22-5pm-3-team03.herokuapp.com>
 * QA Deployment: <https://f22-5pm-3-team03-qa.herokuapp.com>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -93,7 +93,7 @@ function App() {
         {
           hasRole(currentUser, "ROLE_USER") && (
             <>
-              <Route exact path="/ucsborganizations/list" element={<UCSBOrganizationsIndexPage />} />
+              <Route exact path="/ucsborganization/list" element={<UCSBOrganizationIndexPage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
+import OrganizationIndexPage from "main/pages/Organizations/OrganizationIndexPage";
 
 
 function App() {
@@ -70,6 +71,13 @@ function App() {
             <>
               <Route exact path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
               <Route exact path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/organization/list" element={<OrganizationIndexPage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,7 +20,7 @@ import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
-import OrganizationIndexPage from "main/pages/Organizations/OrganizationIndexPage";
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
 
 
 function App() {
@@ -77,7 +77,7 @@ function App() {
         {
           hasRole(currentUser, "ROLE_USER") && (
             <>
-              <Route exact path="/organization/list" element={<OrganizationIndexPage />} />
+              <Route exact path="/ucsborganization/list" element={<UCSBOrganizationIndexPage />} />
             </>
           )
         }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -79,11 +79,6 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="UCSBOrganization" id="appnavbar-ucsborganization-dropdown" data-testid="appnavbar-ucsborganization-dropdown" >
                     <NavDropdown.Item as={Link} to="/ucsborganization/list" data-testid="appnavbar-ucsborganization-list">List UCSB Organizations</NavDropdown.Item>
-                    {
-                      hasRole(currentUser, "ROLE_ADMIN") && (
-                        <NavDropdown.Item as={Link} to="/ucsborganization/create" data-testid="appnavbar-ucsborganization-create">Create</NavDropdown.Item>
-                      )
-                    }
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -75,6 +75,18 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   </NavDropdown>
                 )
               }
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="UCSBOrganization" id="appnavbar-ucsborganization-dropdown" data-testid="appnavbar-ucsborganization-dropdown" >
+                    <NavDropdown.Item as={Link} to="/ucsborganization/list" data-testid="appnavbar-ucsborganization-list">List</NavDropdown.Item>
+                    {
+                      hasRole(currentUser, "ROLE_ADMIN") && (
+                        <NavDropdown.Item as={Link} to="/ucsborganization/create" data-testid="appnavbar-ucsborganization-create">Create</NavDropdown.Item>
+                      )
+                    }
+                  </NavDropdown>
+                )
+              }
             </Nav>
 
             <Nav className="ml-auto">

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -78,7 +78,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               {
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="UCSBOrganization" id="appnavbar-ucsborganization-dropdown" data-testid="appnavbar-ucsborganization-dropdown" >
-                    <NavDropdown.Item as={Link} to="/ucsborganization/list" data-testid="appnavbar-ucsborganization-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/ucsborganization/list" data-testid="appnavbar-ucsborganization-list">List UCSB Organizations</NavDropdown.Item>
                     {
                       hasRole(currentUser, "ROLE_ADMIN") && (
                         <NavDropdown.Item as={Link} to="/ucsborganization/create" data-testid="appnavbar-ucsborganization-create">Create</NavDropdown.Item>

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
@@ -4,7 +4,7 @@ export default function UCSBOrganizationIndexPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Articles</h1>
+        <h1>UCSBOrganization</h1>
         <p>
           This is where the index page will go
         </p>

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBOrganizationIndexPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Articles</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -236,6 +236,54 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId(/appnavbar-dining-commons-list/)).toBeInTheDocument() );
 
     });
+
+    test("renders the ucsborganization menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsborganization-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsborganization-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-ucsborganization-list")).toBeInTheDocument() );
+
+    });
+
+    test("renders the ucsborganization menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsborganization-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsborganization-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-ucsborganization-create/)).toBeInTheDocument() );
+
+    });
    
 });
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -281,8 +281,6 @@ describe("AppNavbar tests", () => {
         const aElement = dropdown.querySelector("a");
         expect(aElement).toBeInTheDocument();
         aElement?.click();
-        await waitFor( () => expect(getByTestId(/appnavbar-ucsborganization-create/)).toBeInTheDocument() );
-
     });
    
 });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
@@ -7,13 +7,11 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import mockConsole from "jest-mock-console";
 
 
 describe("UCSBOrganizationIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
-    const testId = "UCSBOrganizationTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
@@ -1,0 +1,65 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+describe("UCSBOrganizationIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    const testId = "UCSBOrganizationTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsborganization/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsborganization/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+    });
+
+});
+
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,105 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+
+@Api(description = "UCSBOrganization")
+@RequestMapping("/api/UCSBOrganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @ApiOperation(value = "List API for all the UCSB Organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allOrgs() {
+        Iterable<UCSBOrganization> orgs = ucsbOrganizationRepository.findAll();
+        return orgs;
+    }
+
+    @ApiOperation(value = "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @ApiParam("id") @RequestParam String id) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+        return org;
+    }
+
+    @ApiOperation(value = "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrgs(
+        @ApiParam("orgCode") @RequestParam String orgCode,
+        @ApiParam("orgTranslationShort") @RequestParam String orgTranslationShort,
+        @ApiParam("orgTranslation") @RequestParam String orgTranslation,
+        @ApiParam("inactive") @RequestParam boolean inactive
+        )
+        {
+
+        UCSBOrganization newOrg = new UCSBOrganization();
+        newOrg.setOrgCode(orgCode);
+        newOrg.setOrgTranslationShort(orgTranslationShort);
+        newOrg.setOrgTranslation(orgTranslation);
+        newOrg.setInactive(inactive);
+
+        UCSBOrganization savedOrg = ucsbOrganizationRepository.save(newOrg);
+
+        return savedOrg;
+    }
+
+    @ApiOperation(value = "Delete a UCSB Organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteOrg(
+            @ApiParam("id") @RequestParam String id) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+        ucsbOrganizationRepository.delete(org);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(id));
+    }
+
+    @ApiOperation(value = "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrg(
+            @ApiParam("id") @RequestParam String id,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization org = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+        org.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        org.setOrgTranslation(incoming.getOrgTranslation());
+        org.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(org);
+
+        return org;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganization")
+public class UCSBOrganization {
+    @Id
+    private String orgCode;
+    private String orgTranslationShort;
+    private String orgTranslation;
+    private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+    
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,310 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBOrganizationRepository ucsbOrganizationRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/UCSBOrganization/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/UCSBOrganization?id=POINT"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/ucsborganization/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBOrganization/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBOrganization/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                UCSBOrganization orgs = UCSBOrganization.builder()
+                                .orgCode("POINT")
+                                .orgTranslationShort("POINT (Physics)")
+                                .orgTranslation("Physics Organization for Innovation and Technology")
+                                .inactive(false)
+                                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("POINT"))).thenReturn(Optional.of(orgs));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?id=POINT"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("POINT"));
+                String expectedJson = mapper.writeValueAsString(orgs);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("VRL"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?id=VRL"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("VRL"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id VRL not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdiningcommons() throws Exception {
+
+                // arrange
+
+                UCSBOrganization point = UCSBOrganization.builder()
+                                .orgCode("POINT T")
+                                .orgTranslationShort("POINT (Technology)")
+                                .orgTranslation("Physics Organization for Innovation and Technology")
+                                .inactive(true)
+                                .build();
+
+                UCSBOrganization vrl = UCSBOrganization.builder()
+                                .orgTranslationShort("Virl")
+                                .orgTranslation("Vision Research Laboratory")
+                                .inactive(false)
+                                .build();
+
+                ArrayList<UCSBOrganization> expectedOrgs = new ArrayList<>();
+                expectedOrgs.addAll(Arrays.asList(point, vrl));
+
+                when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrgs);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedOrgs);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_commons() throws Exception {
+                // arrange
+
+                UCSBOrganization dsclub = UCSBOrganization.builder()
+                                .orgCode("DSC")
+                                .orgTranslationShort("DS Club")
+                                .orgTranslation("Data Science Club")
+                                .inactive(true)
+                                .build();
+
+                when(ucsbOrganizationRepository.save(eq(dsclub))).thenReturn(dsclub);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/UCSBOrganization/post?orgCode=DSC&orgTranslationShort=DS Club&orgTranslation=Data Science Club&inactive=true")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).save(dsclub);
+                String expectedJson = mapper.writeValueAsString(dsclub);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_date() throws Exception {
+                // arrange
+
+                UCSBOrganization boardgame = UCSBOrganization.builder()
+                                .orgCode("BGC")
+                                .orgTranslationShort("BG Club")
+                                .orgTranslation("Board Game Club")
+                                .inactive(true)
+                                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("BGC"))).thenReturn(Optional.of(boardgame));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/UCSBOrganization?id=BGC")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("BGC");
+                verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id BGC deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_commons_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("iphone-users"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/UCSBOrganization?id=iphone-users")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("iphone-users");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id iphone-users not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_commons() throws Exception {
+                // arrange
+
+                UCSBOrganization facultyOrig = UCSBOrganization.builder()
+                                .orgCode("fac")
+                                .orgTranslationShort("faculty")
+                                .orgTranslation("Faculty Workers Only")
+                                .inactive(false)
+                                .build();
+
+                UCSBOrganization facultyEdited = UCSBOrganization.builder()
+                                .orgCode("fac")
+                                .orgTranslationShort("faculty & students")
+                                .orgTranslation("Faculty and Student Workers")
+                                .inactive(true)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(facultyEdited);
+
+                when(ucsbOrganizationRepository.findById(eq("fac"))).thenReturn(Optional.of(facultyOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/UCSBOrganization?id=fac")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("fac");
+                verify(ucsbOrganizationRepository, times(1)).save(facultyEdited); // should be saved with updated info
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_commons_that_does_not_exist() throws Exception {
+                // arrange
+
+                UCSBOrganization editedOrgs = UCSBOrganization.builder()
+                                .orgCode("FM")
+                                .orgTranslationShort("F. Machines")
+                                .orgTranslation("Fast Machines")
+                                .inactive(true)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(editedOrgs);
+
+                when(ucsbOrganizationRepository.findById(eq("FM"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/UCSBOrganization?id=FM")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("FM");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id FM not found", json.get("message"));
+
+        }
+}


### PR DESCRIPTION
Add a placeholder to the UCSBOrganization Index Page for the nav bar to redirect to
closes #27 

# Acceptance Criteria
- [x] There is a page that shows up when the user goes to `ucsborganization/list`
- [x] The page file should be called `UCSBOrganizationIndexPage` and should be placed in `frontend/src/main/pages/UCSBOrganization`
- [x] The page is linked to in `App.js` and can be accessed by logged-in users