### PR TITLE
8 add helprequest component to storybook along with fixtures

### DIFF
--- a/frontend/src/fixtures/helpRequestsFixtures.js
+++ b/frontend/src/fixtures/helpRequestsFixtures.js
@@ -1,0 +1,43 @@
+const helpRequestsFixtures = {
+    oneDate: {
+        "id": 1,
+        "requesterEmail": "cgaucho@ucsb.edu",
+        "teamId": "7",
+        "tableOrBreakoutRoom": "3",
+        "requestTime": "2022-01-02T12:00:00",
+        "explanation": "Need help with lab03",
+        "solved": false,
+    },
+    threeDates: [
+        {
+            "id": 1,
+            "requesterEmail": "cgaucho@ucsb.edu",
+            "teamId": "7",
+            "tableOrBreakoutRoom": "3",
+            "requestTime": "2022-01-02T12:00:00",
+            "explanation": "Need help with lab03",
+            "solved": false,
+        },
+        {
+            "id": 2,
+            "requesterEmail": "bgaucho@ucsb.edu",
+            "teamId": "14",
+            "tableOrBreakoutRoom": "8",
+            "requestTime": "2022-01-02T15:00:00",
+            "explanation": "Need help with github repo",
+            "solved": true,
+        },
+        {
+            "id": 3,
+            "requesterEmail": "agaucho@ucsb.edu",
+            "teamId": "22",
+            "tableOrBreakoutRoom": "1",
+            "requestTime": "2020-05-02T15:00:00",
+            "explanation": "how to cs?",
+            "solved": true,
+        }
+    ]
+};
+
+
+export { helpRequestsFixtures };

--- a/frontend/src/fixtures/helpRequestsFixtures.js
+++ b/frontend/src/fixtures/helpRequestsFixtures.js
@@ -1,5 +1,5 @@
 const helpRequestsFixtures = {
-    oneDate: {
+    oneHelpRequest: {
         "id": 1,
         "requesterEmail": "cgaucho@ucsb.edu",
         "teamId": "7",
@@ -8,7 +8,7 @@ const helpRequestsFixtures = {
         "explanation": "Need help with lab03",
         "solved": false,
     },
-    threeDates: [
+    threeHelpRequests: [
         {
             "id": 1,
             "requesterEmail": "cgaucho@ucsb.edu",

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,7 +1,7 @@
 import OurTable from "main/components/OurTable";
-import { hasRole } from "main/utils/currentUser";
 
-export default function HelpRequestsTable({ helpRequests, currentUser }) {
+
+export default function HelpRequestsTable({ helpRequests, _currentUser }) {
 
     const columns = [
         {

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,4 +1,4 @@
-import OurTable, { ButtonColumn } from "main/components/OurTable";
+import OurTable from "main/components/OurTable";
 import { hasRole } from "main/utils/currentUser";
 
 export default function HelpRequestsTable({ helpRequests, currentUser }) {
@@ -30,17 +30,18 @@ export default function HelpRequestsTable({ helpRequests, currentUser }) {
         },
         {
             Header: 'Solved?',
-            accessor: 'solved',
+            id: 'solved',
+            accessor: (row, _rowIndex) => String(row.solved)
         }
     ];
 
-    const columnsIfAdmin = [
-        ...columns,
-        // ButtonColumn("Edit", "primary", editCallback, "HelpRequestsTable"),
-        // ButtonColumn("Delete", "danger", deleteCallback, "HelpRequestsTable")
-    ];
+    // const columnsIfAdmin = [
+    //     ...columns,
+    //     // ButtonColumn("Edit", "primary", editCallback, "HelpRequestsTable"),
+    //     // ButtonColumn("Delete", "danger", deleteCallback, "HelpRequestsTable")
+    // ];
 
-    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={helpRequests}

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,0 +1,50 @@
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { hasRole } from "main/utils/currentUser";
+
+export default function HelpRequestsTable({ helprequests, currentUser }) {
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Requester Email',
+            accessor: 'requesterEmail',
+        },
+        {
+            Header: 'Team Id',
+            accessor: 'teamId',
+        },
+        {
+            Header: 'Table or Breakout Room',
+            accessor: 'tableOrBreakoutRoom',
+        },
+        {
+            Header: 'Request Time',
+            accessor: 'requestTime',
+        },
+        {
+            Header: 'Explanation',
+            accessor: 'explanation',
+        },
+        {
+            Header: 'Solved',
+            accessor: 'solved',
+        }
+    ];
+
+    const columnsIfAdmin = [
+        ...columns,
+        // ButtonColumn("Edit", "primary", editCallback, "HelpRequestsTable"),
+        // ButtonColumn("Delete", "danger", deleteCallback, "HelpRequestsTable")
+    ];
+
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    return <OurTable
+        data={helprequests}
+        columns={columnsToDisplay}
+        testid={"HelpRequestsTable"}
+    />;
+};

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -45,7 +45,7 @@ export default function HelpRequestsTable({ helpRequests, currentUser }) {
 
     return <OurTable
         data={helpRequests}
-        columns={columnsToDisplay}
+        columns={columns}
         testid={"HelpRequestsTable"}
     />;
 };

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,11 +1,11 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { hasRole } from "main/utils/currentUser";
 
-export default function HelpRequestsTable({ helprequests, currentUser }) {
+export default function HelpRequestsTable({ helpRequests, currentUser }) {
 
     const columns = [
         {
-            Header: 'id',
+            Header: 'Id',
             accessor: 'id', // accessor is the "key" in the data
         },
         {
@@ -29,7 +29,7 @@ export default function HelpRequestsTable({ helprequests, currentUser }) {
             accessor: 'explanation',
         },
         {
-            Header: 'Solved',
+            Header: 'Solved?',
             accessor: 'solved',
         }
     ];
@@ -43,7 +43,7 @@ export default function HelpRequestsTable({ helprequests, currentUser }) {
     const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
-        data={helprequests}
+        data={helpRequests}
         columns={columnsToDisplay}
         testid={"HelpRequestsTable"}
     />;

--- a/frontend/src/stories/components/HelpRequests/HelpRequestsTable.stories.js
+++ b/frontend/src/stories/components/HelpRequests/HelpRequestsTable.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import HelpRequestsTable from "main/components/HelpRequests/HelpRequestsTable";
+import { helpRequestsFixtures } from 'fixtures/helpRequestsFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/HelpRequests/HelpRequestsTable',
+    component: HelpRequestsTable
+};
+
+const Template = (args) => {
+    return (
+        <HelpRequestsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    helpRequests: []
+};
+
+export const ThreeHelpRequests = Template.bind({});
+
+ThreeHelpRequests.args = {
+    helpRequests: helpRequestsFixtures.threeHelpRequests
+};
+
+export const ThreeHelpRequestsAsAdmin = Template.bind({});
+
+ThreeHelpRequestsAsAdmin.args = {
+    helpRequests: helpRequestsFixtures.threeHelpRequests,
+    currentUser: currentUserFixtures.adminUser
+};

--- a/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
@@ -1,0 +1,99 @@
+import {  render } from "@testing-library/react";
+import { helpRequestsFixtures } from "fixtures/helpRequestsFixtures";
+import HelpRequestsTable from "main/components/HelpRequests/HelpRequestsTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("HelpRequestsTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected column headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={helpRequestsFixtures.threeHelpRequests} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    const expectedHeaders = ['Id',  'Requester Email', 'Team Id','Table or Breakout Room','Request Time','Explanation','Solved?'];
+    const expectedFields = ['id', 'requesterEmail','teamId', 'tableOrBreakoutRoom','requestTime','explanation','solved'];
+    const testId = "HelpRequestsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(1);
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(2);
+    expect(getByTestId(`${testId}-cell-row-0-col-explanation`)).toHaveTextContent("Need help with lab03");
+    expect(getByTestId(`${testId}-cell-row-1-col-teamId`)).toHaveTextContent("14");
+
+    // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // expect(editButton).toHaveClass("btn-primary");
+
+    // const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    // expect(deleteButton).toBeInTheDocument();
+    // expect(deleteButton).toHaveClass("btn-danger");
+  });
+});

--- a/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
@@ -87,7 +87,7 @@ describe("HelpRequestsTable tests", () => {
     expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(2);
     expect(getByTestId(`${testId}-cell-row-0-col-explanation`)).toHaveTextContent("Need help with lab03");
     expect(getByTestId(`${testId}-cell-row-1-col-teamId`)).toHaveTextContent("14");
-    expect(getByTestId(`${testId}-cell-row-1-col-sovled`)).toHaveTextContent("true");
+    expect(getByTestId(`${testId}-cell-row-1-col-solved`)).toHaveTextContent("true");
 
     // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     // expect(editButton).toBeInTheDocument();

--- a/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
@@ -87,6 +87,7 @@ describe("HelpRequestsTable tests", () => {
     expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(2);
     expect(getByTestId(`${testId}-cell-row-0-col-explanation`)).toHaveTextContent("Need help with lab03");
     expect(getByTestId(`${testId}-cell-row-1-col-teamId`)).toHaveTextContent("14");
+    expect(getByTestId(`${testId}-cell-row-1-col-sovled`)).toHaveTextContent("true");
 
     // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     // expect(editButton).toBeInTheDocument();


### PR DESCRIPTION
Closes #8 
- [x] There is a `HelpRequestsTable.js` file in `frontend/main/components/HelpRequests`.
- [x] There is a `helpRequestsFixtures.js` file in `frontend/src/fixtures`  with an example `oneHelpRequest` and an example `threeHelpRequests`.
- [x] There is a `HelpRequestsTable.stories.js` file in `frontend/src/stories/components/Articles`.
- [x] In the storybook there is an `HelpRequests` Folder with a `HelpRequestsTable` inside with `Empty` , `Three Articles` , and `Three Help Requests as Admin`.
- [x] When `Empty` is clicked there is a table with all of the headers of an article but with no items in the table.
- [x] When `Three Help Requests` is clicked there is a table with all of the headers of an article with three items in the table with the correct values corresponding to the values in the `articlesFixtures.js` file.
- [x] There is a corresponding `HelpRequestsTable.test.js` that tests `HelpRequests.js`.