### PR TITLE
28 AK add organizationtable component to storybook along with fixtures

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,31 @@
+const ucsbOrganizationFixtures = {
+    oneUCSBOrganization: {
+        "orgCode": "POINT",
+        "orgTranslationShort": "Phys Org Inn & Tech",
+        "orgTranslation": "Physics Organization for Innovation and Technology",
+        "inactive": false,
+    },
+    threeUCSBOrganization: [
+        {
+            "orgCode": "POINT",
+            "orgTranslationShort": "Physics Innovation Technology",
+            "orgTranslation": "Physics Organization for Innovation and Technology",
+            "inactive": false,
+        },
+        {
+            "orgCode": "CRANE",
+            "orgTranslationShort": "College Rage",
+            "orgTranslation": "College Rage and Animosity Nomenclature Enumeration",
+            "inactive": true,
+        },
+        {
+            "orgCode": "DREAM",
+            "orgTranslationShort": "Dragon Rail",
+            "orgTranslation": "Dragon Rail for Engineering Art Majors",
+            "inactive": false,
+        }
+    ]
+};
+
+
+export { ucsbOrganizationFixtures };

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -1,6 +1,6 @@
 import OurTable from "main/components/OurTable";
 
-export default function UCSBOrganizationTable({ dates, _currentUser }) {
+export default function UCSBOrganizationTable({ ucsborganization, _currentUser }) {
 
     const columns = [
         {
@@ -22,7 +22,7 @@ export default function UCSBOrganizationTable({ dates, _currentUser }) {
     ];
 
     return <OurTable
-        data={dates}
+        data={ucsborganization}
         columns={columns}
         testid={"UCSBOrganizationTable"}
     />;

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -1,0 +1,33 @@
+import OurTable from "main/components/OurTable";
+
+export default function UCSBOrganizationTable({ dates, currentUser }) {
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'UCSB Organization Code',
+            accessor: 'orgCode',
+        },
+        {
+            Header: 'UCSB Organization Short Translation',
+            accessor: 'orgTranslationShort',
+        },
+        {
+            Header: 'UCSB Organization Translation',
+            accessor: 'orgTranslation',
+        },
+        {
+            Header: 'UCSB Organization is Inactive',
+            accessor: 'inactive',
+        }
+    ];
+
+    return <OurTable
+        data={dates}
+        columns={columnsToDisplay}
+        testid={"UCSBOrganizationTable"}
+    />;
+};

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -4,10 +4,6 @@ export default function UCSBOrganizationTable({ dates, currentUser }) {
 
     const columns = [
         {
-            Header: 'id',
-            accessor: 'id', // accessor is the "key" in the data
-        },
-        {
             Header: 'UCSB Organization Code',
             accessor: 'orgCode',
         },

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -1,6 +1,6 @@
 import OurTable from "main/components/OurTable";
 
-export default function UCSBOrganizationTable({ dates, currentUser }) {
+export default function UCSBOrganizationTable({ dates, _currentUser }) {
 
     const columns = [
         {
@@ -23,7 +23,7 @@ export default function UCSBOrganizationTable({ dates, currentUser }) {
 
     return <OurTable
         data={dates}
-        columns={columnsToDisplay}
+        columns={columns}
         testid={"UCSBOrganizationTable"}
     />;
 };

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
@@ -21,7 +21,7 @@ Empty.args = {
     articles: []
 };
 
-export const threeUCSBOrganization = Template.bind({});
+export const ThreeUCSBOrganization = Template.bind({});
 
 ThreeUCSBOrganization.args = {
     ucsbOrganization: ucsbOrganizationFixtures.threeUCSBOrganization

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/UCSBOrganization/UCSBOrganizationTable',
+    component: UCSBOrganizationTable
+};
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    articles: []
+};
+
+export const threeUCSBOrganization = Template.bind({});
+
+ThreeUCSBOrganization.args = {
+    ucsbOrganization: ucsbOrganizationFixtures.threeUCSBOrganization
+};
+
+export const ThreeUCSBOrganizationAsAdmin = Template.bind({});
+
+ThreeUCSBOrganizationAsAdmin.args = {
+    ucsbOrganization: ucsbOrganizationFixtures.threeUCSBOrganization,
+    currentUser: currentUserFixtures.adminUser
+};

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
@@ -18,18 +18,18 @@ const Template = (args) => {
 export const Empty = Template.bind({});
 
 Empty.args = {
-    articles: []
+    ucsborganization: []
 };
 
 export const ThreeUCSBOrganization = Template.bind({});
 
 ThreeUCSBOrganization.args = {
-    ucsbOrganization: ucsbOrganizationFixtures.threeUCSBOrganization
+    ucsborganization: ucsbOrganizationFixtures.threeUCSBOrganization
 };
 
 export const ThreeUCSBOrganizationAsAdmin = Template.bind({});
 
 ThreeUCSBOrganizationAsAdmin.args = {
-    ucsbOrganization: ucsbOrganizationFixtures.threeUCSBOrganization,
+    ucsborganization: ucsbOrganizationFixtures.threeUCSBOrganization,
     currentUser: currentUserFixtures.adminUser
 };

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
@@ -1,0 +1,90 @@
+import {  render } from "@testing-library/react";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBOrganizationTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable articles={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable ucsborganization={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable ucsborganization={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected column headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable ucsborganization={ucsbOrganizationFixtures.threeUCSBOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ['UCSB Organization Code', 'UCSB Organization Short Translation', 'UCSB Organization Translation', 'UCSB Organization is Inactive'];
+    const expectedFields = ['orgCode', 'orgTranslationShort', 'orgTranslation', 'inactive'];
+    const testId = "UCSBOrganizationTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("POINT");
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("CRANE");
+    expect(getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent("Physics Innovation Technology");
+    expect(getByTestId(`${testId}-cell-row-1-col-title`)).toHaveTextContent("College Rage");
+  });
+});

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
@@ -1,4 +1,4 @@
-import {  render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
 import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -23,7 +23,7 @@ describe("UCSBOrganizationTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBOrganizationTable articles={[]} currentUser={currentUser} />
+          <UCSBOrganizationTable ucsborganization={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -82,9 +82,9 @@ describe("UCSBOrganizationTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("POINT");
-    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("CRANE");
-    expect(getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent("Physics Innovation Technology");
-    expect(getByTestId(`${testId}-cell-row-1-col-title`)).toHaveTextContent("College Rage");
+    expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("POINT");
+    expect(getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("CRANE");
+    expect(getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("Physics Innovation Technology");
+    expect(getByTestId(`${testId}-cell-row-1-col-orgTranslationShort`)).toHaveTextContent("College Rage");
   });
 });


### PR DESCRIPTION
Add the UCSBOrganization Table to the storybook under the `frontend` folder. The storybook if for checking that all the components from different views

# Acceptance Criteria
- [x] There is a `UCSBOrganizationTable.js` file in `frontend/src/main/components/ucsborganization`.
- [x] There is a `ucsborganizationFixtures.js` file in `frontend/src/fixtures`  with an example `oneUCSBOrganization` and an example `threeUCSBOrganizations`.
- [x] There is a `UCSBOrganizationsTable.stories.js` file in `frontend/src/stories/components/UCSBOrganization`.
- [x] In the storybook there is an `UCSBOrganization` Folder with a `UCSBOrganizationTable` Inside with `Empty` and `Three UCSBOrganizations`.
- [x] When `Empty` is clicked there is a table with all of the headers of a ucsborganization but with no items in the table.
- [x] When `Three UCSBOrganizations` is clicked there is a table with all of the headers of a ucsborganization with three items in the table with the correct values corresponding to the values in the `ucsborganizationFixtures.js` file.
- [x] There is a corresponding `UCSBOrganizationTable.test.js` that tests `UCSBOrganizationTable.js`.