### PR TITLE
Colter menu item placeholder

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,7 @@ import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
+import MenuItemIndexPage from "main/pages/MenuItem/MenuItemIndexPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -70,6 +71,13 @@ function App() {
             <>
               <Route exact path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
               <Route exact path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
+            </>
+          )
+        }
+		{
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/ucsbdiningcommonsmenuitem/list" element={<MenuItemIndexPage />} />
             </>
           )
         }

--- a/frontend/src/main/pages/MenuItem/MenuItemIndexPage.js
+++ b/frontend/src/main/pages/MenuItem/MenuItemIndexPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemIndexPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Menu Items</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/pages/MenuItem/MenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItem/MenuItemIndexPage.test.js
@@ -1,0 +1,74 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import MenuItemIndexPage from "main/pages/MenuItem/MenuItemIndexPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("MenuItemIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "MenuItemTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+
+});

--- a/frontend/src/tests/pages/MenuItem/MenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItem/MenuItemIndexPage.test.js
@@ -22,7 +22,7 @@ describe("MenuItemIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
 
-    const testId = "MenuItemTable";
+    const _testId = "MenuItemTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();


### PR DESCRIPTION
In this PR, I added a placeholder page for MenuItem and associated tests. That has been linked to the route /ucsbdiningcommonsmenuitem/list in App.js

When a user visits the the /ucsbdiningcommonsmenuitem/list page, they find a placeholder page.

Closes #22 