### PR TITLE
Harvard - add delete column to Help Request table

### DIFF
--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -20,7 +20,7 @@ export default function HelpRequestsTable({ helpRequests, currentUser }) {
      const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
-        ["/api/ucsbdiningcommons/all"]
+        ["/api/HelpRequest/all"]
     );
     // Stryker enable all 
 

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,7 +1,31 @@
-import OurTable from "main/components/OurTable";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import {  onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { hasRole } from "main/utils/currentUser";
 
 
-export default function HelpRequestsTable({ helpRequests, _currentUser }) {
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/HelpRequest",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+
+export default function HelpRequestsTable({ helpRequests, currentUser }) {
+
+     // Stryker disable all : hard to test for query caching
+     const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/ucsbdiningcommons/all"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
     const columns = [
         {
@@ -35,17 +59,17 @@ export default function HelpRequestsTable({ helpRequests, _currentUser }) {
         }
     ];
 
-    // const columnsIfAdmin = [
-    //     ...columns,
-    //     // ButtonColumn("Edit", "primary", editCallback, "HelpRequestsTable"),
-    //     // ButtonColumn("Delete", "danger", deleteCallback, "HelpRequestsTable")
-    // ];
+    const columnsIfAdmin = [
+        ...columns,
+        // ButtonColumn("Edit", "primary", editCallback, "HelpRequestsTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, "HelpRequestsTable")
+    ];
 
-    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={helpRequests}
-        columns={columns}
+        columns={columnsToDisplay}
         testid={"HelpRequestsTable"}
     />;
 };

--- a/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
@@ -93,8 +93,8 @@ describe("HelpRequestsTable tests", () => {
     // expect(editButton).toBeInTheDocument();
     // expect(editButton).toHaveClass("btn-primary");
 
-    // const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    // expect(deleteButton).toBeInTheDocument();
-    // expect(deleteButton).toHaveClass("btn-danger");
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
   });
 });

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import HelpRequestsIndexPage from "main/pages/HelpRequests/HelpRequestsIndexPage";
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -150,35 +150,35 @@ describe("HelpRequestsIndexPage tests", () => {
         expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });
 
-    // test("test what happens when you click delete, admin", async () => {
-    //     setupAdminUser();
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
 
-    //     const queryClient = new QueryClient();
-    //     axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, helpRequestsFixtures.threeCommons);
-    //     axiosMock.onDelete("/api/ucsbdiningcommons", {params: {code: "de-la-guerra"}}).reply(200, "HelpRequests with id de-la-guerra was deleted");
-
-
-    //     const { getByTestId } = render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <HelpRequestsIndexPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
-
-    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toBeInTheDocument(); });
-
-    //    expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); 
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/HelpRequest/all").reply(200, helpRequestsFixtures.threeHelpRequests);
+        axiosMock.onDelete("/api/HelpRequest", {params: {id: 1}}).reply(200, "HelpRequests with id 1 was deleted");
 
 
-    //     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    //     expect(deleteButton).toBeInTheDocument();
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(1); 
+
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
        
-    //     fireEvent.click(deleteButton);
+        fireEvent.click(deleteButton);
 
-    //     await waitFor(() => { expect(mockToast).toBeCalledWith("HelpRequests with id de-la-guerra was deleted") });
+        await waitFor(() => { expect(mockToast).toBeCalledWith("HelpRequests with id 1 was deleted") });
 
-    // });
+    });
 
     // test("test what happens when you click edit as an admin", async () => {
     //     setupAdminUser();


### PR DESCRIPTION
closes #13 
- [x] When `Three Articles as Admin` is clicked in storybook a table with all of the headers of a help request plus a delete header with three items in the table with the correct values corresponding to the values in the `helpRequestsFixtures.js` file each row also contains a delete button under the delete header.
- [x] When an admin user presses one of the delete buttons on the articles list page, the corresponding article is deleted from the database and the page updates to show so.
- [x] Everything has full test coverage
- [x] Everything has full mutation coverage
- [x] Everything works when tested locally
- [x] Storybook shows up without errors at https://ucsb-cs156-f22.github.io/team03-f22-5pm-3-docs-qa/
- [x] Everything works when tested on heroku