### PR TITLE
30 AK add deletecolumn to organizationtable

### DIFF
--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -43,7 +43,8 @@ export default function UCSBOrganizationTable({ ucsborganization, currentUser })
         },
         {
             Header: 'UCSB Organization is Inactive',
-            accessor: 'inactive',
+            id: 'inactive',
+            accessor: (row, _rowIndex) => String(row.inactive) // hack needed for boolean values to show up
         }
     ];
 

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -8,7 +8,7 @@ export function cellToAxiosParamsDelete(cell) {
         url: "/api/UCSBOrganization",
         method: "DELETE",
         params: {
-            orgCode: cell.row.values.orgCode
+            id: cell.row.values.orgCode
         }
     }
 }

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -1,6 +1,32 @@
-import OurTable from "main/components/OurTable";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { onDeleteSuccess } from "main/utils/UCSBDateUtils";
+import { hasRole } from "main/utils/currentUser";
 
-export default function UCSBOrganizationTable({ ucsborganization, _currentUser }) {
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/UCSBOrganization",
+        method: "DELETE",
+        params: {
+            orgCode: cell.row.values.orgCode
+        }
+    }
+}
+
+export default function UCSBOrganizationTable({ ucsborganization, currentUser }) {
+
+    // Stryker disable all : hard to test for query caching
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/UCSBOrganization/all"],
+    )
+    // Stryker enable all
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => {
+        deleteMutation.mutate(cell);
+    }
 
     const columns = [
         {
@@ -21,9 +47,18 @@ export default function UCSBOrganizationTable({ ucsborganization, _currentUser }
         }
     ];
 
+    const testId = "UCSBOrganizationTable";
+
+    const columnsIfAdmin = [
+        ...columns,
+        ButtonColumn("Delete", "danger", deleteCallback, testId)
+    ];
+
+    const display = hasRole(currentUser, "ROLE_USER") ? columnsIfAdmin : columns;
+
     return <OurTable
         data={ucsborganization}
-        columns={columns}
-        testid={"UCSBOrganizationTable"}
+        columns={display}
+        testid={testId}
     />;
 };

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
@@ -86,5 +86,9 @@ describe("UCSBOrganizationTable tests", () => {
     expect(getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("CRANE");
     expect(getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("Physics Innovation Technology");
     expect(getByTestId(`${testId}-cell-row-1-col-orgTranslationShort`)).toHaveTextContent("College Rage");
+    
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
   });
 });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
@@ -71,6 +71,7 @@ describe("UCSBOrganizationIndexPage tests", () => {
             </QueryClientProvider>
         );
 
+
     });
 
     test("renders three without crashing for regular user", async () => {
@@ -132,6 +133,36 @@ describe("UCSBOrganizationIndexPage tests", () => {
 
         expect(queryByTestId(`${testId}-cell-row-0-col-orgCode`)).not.toBeInTheDocument();
     });
+
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganization/all").reply(200, ucsbOrganizationFixtures.threeUCSBOrganization);
+        axiosMock.onDelete("/api/UCSBOrganization", { params : { orgCode : "POINT" } }).reply(200, "UCSBOrganization with orgCode POINT was deleted");
+
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toBeInTheDocument(); });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("POINT");
+
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("UCSBOrganization with orgCode POINT was deleted") });
+
+    })
 
 });
 

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
@@ -139,7 +139,7 @@ describe("UCSBOrganizationIndexPage tests", () => {
 
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/UCSBOrganization/all").reply(200, ucsbOrganizationFixtures.threeUCSBOrganization);
-        axiosMock.onDelete("/api/UCSBOrganization", { params : { orgCode : "POINT" } }).reply(200, "UCSBOrganization with orgCode POINT was deleted");
+        axiosMock.onDelete("/api/UCSBOrganization", { params : { id : "POINT" } }).reply(200, "UCSBOrganization with orgCode POINT was deleted");
 
 
         const { getByTestId } = render(


### PR DESCRIPTION
Add the delete column to the ucsb organization table in the index page

# Acceptance Criteria
- [x] Now, In the storybook there is an `UCSBOrganization` Folder with a `UCSBOrganizationTable` Inside with `Empty`, `Three UCSBOrganization`, and `Three UCSBOrganization as Admin`.
- [x] When `Three UCSBOrganization as Admin` is clicked there is a table with all of the headers of a ucsb organization plus a delete header with three items in the table with the correct values corresponding to the values in the `ucsbOrganizationFixtures.js` file each row also contains a delete button under the delete header.
- [x] When the user presses one of the delete buttons on the ucsborganizations list page, the corresponding ucsborganization is deleted from the database and the page updates to show so.
- [x] Everything has full test coverage
- [x] Everything has full mutation coverage
- [x] Everything works when tested locally
- [x] Storybook shows up without errors at https://ucsb-cs156-f22.github.io/team03-f22-5pm-3-docs-qa/
- [x] Everything works when tested on heroku