### PR TITLE
Colter menu item table on index page

### DIFF
--- a/frontend/src/main/components/MenuItem/MenuItemTable.js
+++ b/frontend/src/main/components/MenuItem/MenuItemTable.js
@@ -1,10 +1,11 @@
 import OurTable from "main/components/OurTable";
+import { _hasRole } from "main/utils/currentUser"
 
 export default function MenuItemTable({ menuItems, _currentUser }) {
 
     const columns = [
         {
-            Header: 'id',
+            Header: 'ID',
             accessor: 'id', // accessor is the "key" in the data
         },
         {

--- a/frontend/src/main/pages/MenuItem/MenuItemIndexPage.js
+++ b/frontend/src/main/pages/MenuItem/MenuItemIndexPage.js
@@ -1,13 +1,28 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+
+import MenuItemTable from 'main/components/MenuItem/MenuItemTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function MenuItemIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: menuItems, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/ucsbdiningcommonsmenuitem/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/ucsbdiningcommonsmenuitem/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Menu Items</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <h1>UCSB Dining Commons Menu Items</h1>
+        <MenuItemTable menuItems={menuItems} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
+++ b/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
@@ -55,7 +55,7 @@ describe("MenuItem tests", () => {
     );
   });
 
-  test("Has the expected colum headers and content for adminUser", () => {
+  test("Has the expected column headers and content for adminUser", () => {
 
     const currentUser = currentUserFixtures.adminUser;
 
@@ -68,7 +68,7 @@ describe("MenuItem tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Dining commons", "Meal name", "Serving station"];
+    const expectedHeaders = ["ID", "Dining commons", "Meal name", "Serving station"];
     const expectedFields = ["id", "diningCommonsCode", "name", "station"];
     const testId = "MenuItemTable";
 

--- a/frontend/src/tests/pages/MenuItem/MenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItem/MenuItemIndexPage.test.js
@@ -73,23 +73,6 @@ describe("MenuItemIndexPage tests", () => {
 
     });
 
-	
-    test("renders without crashing for admin user", () => {
-        setupAdminUser();
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, []);
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <MenuItemIndexPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-
-    });
-
     test("renders three menu items without crashing for regular user", async () => {
         setupUserOnly();
         const queryClient = new QueryClient();

--- a/frontend/src/tests/pages/MenuItem/MenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItem/MenuItemIndexPage.test.js
@@ -21,10 +21,16 @@ jest.mock('react-toastify', () => {
     };
 });
 
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
 describe("MenuItemIndexPage tests", () => {
 
-    const axiosMock =new AxiosMockAdapter(axios);
-
+    const axiosMock = new AxiosMockAdapter(axios);
     const testId = "MenuItemTable";
 
     const setupUserOnly = () => {
@@ -90,6 +96,10 @@ describe("MenuItemIndexPage tests", () => {
         expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
         expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
 
+		expect(getByTestId(`${testId}-cell-row-0-col-diningCommonsCode`)).toHaveTextContent("Portola");
+        expect(getByTestId(`${testId}-cell-row-1-col-station`)).toHaveTextContent("Burrito bar");
+        expect(getByTestId(`${testId}-cell-row-2-col-name`)).toHaveTextContent("Chicken vegetable stir fry");
+
     });
 
     test("renders three menu items without crashing for admin user", async () => {
@@ -109,6 +119,10 @@ describe("MenuItemIndexPage tests", () => {
         expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
         expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
 
+		expect(getByTestId(`${testId}-cell-row-0-col-diningCommonsCode`)).toHaveTextContent("Portola");
+        expect(getByTestId(`${testId}-cell-row-1-col-station`)).toHaveTextContent("Burrito bar");
+        expect(getByTestId(`${testId}-cell-row-2-col-name`)).toHaveTextContent("Chicken vegetable stir fry");
+
     });
 
     test("renders empty table when backend unavailable, user only", async () => {
@@ -119,7 +133,7 @@ describe("MenuItemIndexPage tests", () => {
 
         const restoreConsole = mockConsole();
 
-        const { queryByTestId } = render(
+        const { queryByTestId, getByText } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <MenuItemIndexPage />
@@ -129,6 +143,13 @@ describe("MenuItemIndexPage tests", () => {
 
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
         restoreConsole();
+
+		const expectedHeaders = ['ID', 'Dining commons', 'Meal name', 'Serving station'];
+    
+        expectedHeaders.forEach((headerText) => {
+          const header = getByText(headerText);
+          expect(header).toBeInTheDocument();
+        });
 
         expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });


### PR DESCRIPTION
In this PR, I added the MenuItem table to the MenuItem index page accessed from the list option in the Menu Item dropdown. 
Now the index page shows the headers for the MenuItem table and the rows which are inserted from swagger.

Also expanded tests to cover the new functionality of the index page. 

Closes #24 
